### PR TITLE
Move truffle-hdwallet-provider to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "request-promise": "^4.2.2",
     "sol-straightener": "^1.0.0",
     "solidity-parser-antlr": "0.4.3",
-    "truffle-hdwallet-provider": "0.0.6",
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
@@ -47,6 +46,8 @@
     "coveralls": "^3.0.2",
     "eslint": "^5.15.3",
     "mocha": "^5.2.0",
-    "nyc": "^13.1.0"
+    "nyc": "^13.1.0",
+    "solc": "^0.5.12",
+    "truffle-hdwallet-provider": "^1.0.17"
   }
 }

--- a/test/sol-verifier.js
+++ b/test/sol-verifier.js
@@ -12,6 +12,8 @@ function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+const ETHERSCAN_KEY = process.env.KEY;
+
 describe('sol-verifier', () => {
 
   describe('Deploying & Verifying Sample.sol', () => {
@@ -36,7 +38,7 @@ describe('sol-verifier', () => {
     });
     it('Verifies Sample.sol contract successfully', async () => {
       sampleData = {
-        key: process.env.KEY,
+        key: ETHERSCAN_KEY,
         path : path,
         contractAddress:  contractAddress,
         network  : network,
@@ -70,7 +72,7 @@ describe('sol-verifier', () => {
 
     it('Trying to verify contract by passing non-existing Ethereum network (should fail)', async () => {
       const temp = {
-        key: process.env.KEY,
+        key: ETHERSCAN_KEY,
         path : path,
         contractAddress:  contractAddress,
         network  : 'random',
@@ -115,7 +117,7 @@ describe('sol-verifier', () => {
     });
     it('Verifies Sample.sol contract successfully by enabling optimization', async () => {
       sampleData = {
-        key: process.env.KEY,
+        key: ETHERSCAN_KEY,
         path : path,
         contractAddress:  contractAddress,
         network  : network,
@@ -149,7 +151,7 @@ describe('sol-verifier', () => {
     });
     it('Verifies SampleOld.sol contract successfully with old way of defining constructor', async () => {
       sampleData = {
-        key: process.env.KEY,
+        key: ETHERSCAN_KEY,
         path : path,
         contractAddress:  contractAddress,
         network  : network,
@@ -187,7 +189,7 @@ describe('sol-verifier', () => {
 
     it('Verifies SampleWithConstructor.sol contract with array params in constructor successfully', async () => {
       sampleData = {
-        key     : process.env.KEY,
+        key     : ETHERSCAN_KEY,
         path    : path,
         contractAddress:  contractAddress,
         network : network,
@@ -233,7 +235,7 @@ describe('sol-verifier', () => {
 
     it('Verifies MultiContractSample.sol contract successfully', async () => {
       sampleData = {
-        key     : process.env.KEY,
+        key     : ETHERSCAN_KEY,
         path    : path,
         contractAddress:  contractAddress,
         network : network,
@@ -273,7 +275,7 @@ describe('sol-verifier', () => {
       contractAddress = await deployContract(contractName, network, compiler, pathToDeploy);
       await sleep(40000); // To make sure that contractCode is stored
       sampleData = {
-        key     : process.env.KEY,
+        key     : ETHERSCAN_KEY,
         path    : pathToVerify,
         contractAddress:  contractAddress,
         network : network,
@@ -295,7 +297,7 @@ describe('sol-verifier', () => {
       contractAddress = await deployContract(contractName, network, compiler, pathToDeploy);
       await sleep(40000); // To make sure that contractCode is stored
       sampleData = {
-        key     : process.env.KEY,
+        key     : ETHERSCAN_KEY,
         path    : pathToVerify,
         contractAddress:  contractAddress,
         network : network,
@@ -320,7 +322,7 @@ describe('sol-verifier', () => {
       contractAddress = await deployContract(contractName, network, compiler, pathToDeploy, constructParams);
       await sleep(40000); // To make sure that contractCode is stored
       sampleData = {
-        key     : process.env.KEY,
+        key     : ETHERSCAN_KEY,
         path    : pathToVerify,
         contractAddress:  contractAddress,
         network : network,

--- a/test/utils/deploy.js
+++ b/test/utils/deploy.js
@@ -4,10 +4,15 @@ const Web3 = require('web3');
 const HDWalletProvider = require('truffle-hdwallet-provider');
 const solc = require('./solc');
 
+const SEED = process.env.SEED;
+const INFURA_TOKEN = process.env.INFURA_TOKEN;
 
 module.exports.deployContract = async (contractName, network, compiler, contractPath = null, initParams = [], optimize = false) => {// eslint-disable-line max-len
-  const net = 'https://' + network +'.infura.io/';
-  const web3 = new Web3(new HDWalletProvider(process.env.SEED, net));
+  const infuraEndpoint = 'https://' + network +'.infura.io/v3/' + INFURA_TOKEN;
+  const provider = new HDWalletProvider(SEED, infuraEndpoint);
+  const web3 = new Web3(provider);
+  const accounts = await web3.eth.getAccounts();
+  const account = accounts[0];
   if(!contractPath)
     contractPath = __dirname + '/../contracts/'+ contractName + '.sol';
   try{
@@ -18,7 +23,7 @@ module.exports.deployContract = async (contractName, network, compiler, contract
       arguments: initParams,
     })
       .send({
-        from: process.env.ADDRESS,
+        from: account,
       });
     return result.options.address;
   }catch(err){


### PR DESCRIPTION
Reason: `truffle-hdwallet-provider` is used only in test util.

Also, extracted `process.env` references.

There are now three env variables for tests to run:
- `SEED` - bip39 mnemonic,
- `INFURA_TOKEN` - Infura v3 project id, as old free API is dead,
- `KEY` - Etherscan API key.